### PR TITLE
Fix gcc link problem

### DIFF
--- a/ssm-client.spec
+++ b/ssm-client.spec
@@ -12,7 +12,7 @@ Vendor:         Shattered Silicon
 URL:            https://shatteredsilicon.net
 Source:         ssm-client-%{_version}.tar.gz
 AutoReq:        no
-BuildRequires:  glibc-devel, golang, unzip, gzip, make, perl-ExtUtils-MakeMaker, git, systemd
+BuildRequires:  glibc-devel, glibc-static, golang, unzip, gzip, make, perl-ExtUtils-MakeMaker, git, systemd
 
 Obsoletes: pmm-client <= 1.17.5
 Conflicts: pmm-client > 1.17.5


### PR DESCRIPTION
Golang got updated to 1.19 in RHEL 8 recently, and this causes ssm-client rpm building failed with this error:
```
....
+ /usr/bin/make -j4 build
>> building binaries
 >   node_exporter
# github.com/prometheus/node_exporter
/usr/lib/golang/pkg/tool/linux_arm64/link: running gcc failed: exit status 1
/usr/bin/ld: cannot find -lpthread
/usr/bin/ld: cannot find -ldl
/usr/bin/ld: cannot find -lc
collect2: error: ld returned 1 exit status
```

Adding **glibc-static** BuildRequires fixes this