### PR TITLE
Fix bugs caused by the `--create-user` option

### DIFF
--- a/ssm-admin.go
+++ b/ssm-admin.go
@@ -307,7 +307,7 @@ However, you can add another one with the different name just for testing purpos
 
 When adding a MySQL instance, this tool tries to auto-detect the DSN and credentials.
 If you want to create a new user to be used for metrics collecting, provide --create-user option. ssm-admin will create
-a new user 'pmm@' automatically using the given (auto-detected) MySQL credentials for granting purpose.
+a new user 'ssm@' automatically using the given (auto-detected) MySQL credentials for granting purpose.
 
 Table statistics is automatically disabled when there are more than 10000 tables on MySQL.
 
@@ -356,7 +356,7 @@ Table statistics is automatically disabled when there are more than 10000 tables
 			}
 
 			mysqlQueries := mysqlQueries.New(flagQueries, flagMySQLQueries, flagMySQL)
-			info, err = admin.AddQueries(ctx, mysqlQueries)
+			info, err = admin.AddQueries(ctx, mysqlQueries, info)
 			if err == ssm.ErrDuplicate {
 				fmt.Println("[mysql:queries] OK, already monitoring MySQL queries.")
 			} else if err != nil {
@@ -375,7 +375,7 @@ Table statistics is automatically disabled when there are more than 10000 tables
 
 When adding a MySQL instance, this tool tries to auto-detect the DSN and credentials.
 If you want to create a new user to be used for metrics collecting, provide --create-user option. ssm-admin will create
-a new user 'pmm@' automatically using the given (auto-detected) MySQL credentials for granting purpose.
+a new user 'ssm@' automatically using the given (auto-detected) MySQL credentials for granting purpose.
 
 Table statistics is automatically disabled when there are more than 10000 tables on MySQL.
 
@@ -405,7 +405,7 @@ Table statistics is automatically disabled when there are more than 10000 tables
 
 When adding a MySQL instance, this tool tries to auto-detect the DSN and credentials.
 If you want to create a new user to be used for query collecting, provide --create-user option. ssm-admin will create
-a new user 'pmm@' automatically using the given (auto-detected) MySQL credentials for granting purpose.
+a new user 'ssm@' automatically using the given (auto-detected) MySQL credentials for granting purpose.
 
 [name] is an optional argument, by default it is set to the client name of this SSM client.
 		`,
@@ -428,7 +428,7 @@ Type ssm-admin add mysql:queries --help to see all acceptable flags.
 				os.Exit(1)
 			}
 			mysqlQueries := mysqlQueries.New(flagQueries, flagMySQLQueries, flagMySQL)
-			info, err := admin.AddQueries(ctx, mysqlQueries)
+			info, err := admin.AddQueries(ctx, mysqlQueries, nil)
 			if err != nil {
 				fmt.Println("Error adding MySQL queries:", err)
 				os.Exit(1)
@@ -445,7 +445,7 @@ Type ssm-admin add mysql:queries --help to see all acceptable flags.
 
 When adding a PostgreSQL instance, this tool tries to auto-detect the DSN and credentials.
 If you want to create a new user to be used for metrics collecting, provide --create-user option. ssm-admin will create
-a new user 'pmm' automatically using the given (auto-detected) PostgreSQL credentials for granting purpose.
+a new user 'ssm' automatically using the given (auto-detected) PostgreSQL credentials for granting purpose.
 
 [name] is an optional argument, by default it is set to the client name of this SSM client.
 		`,
@@ -493,7 +493,7 @@ a new user 'pmm' automatically using the given (auto-detected) PostgreSQL creden
 
 When adding a PostgreSQL instance, this tool tries to auto-detect the DSN and credentials.
 If you want to create a new user to be used for metrics collecting, provide --create-user option. ssm-admin will create
-a new user 'pmm' automatically using the given (auto-detected) PostgreSQL credentials for granting purpose.
+a new user 'ssm' automatically using the given (auto-detected) PostgreSQL credentials for granting purpose.
 
 [name] is an optional argument, by default it is set to the client name of this SSM client.
 [exporter_args] are the command line options to be passed directly to Prometheus Exporter.
@@ -559,7 +559,7 @@ When adding a MongoDB instance, you may provide --uri if the default one does no
 			}
 
 			mongodbQueries := mongodbQueries.New(flagQueries, flagMongoURI, admin.Args, ssm.SSMBaseDir)
-			info, err = admin.AddQueries(ctx, mongodbQueries)
+			info, err = admin.AddQueries(ctx, mongodbQueries, info)
 			if err == ssm.ErrDuplicate {
 				fmt.Println("[mongodb:queries] OK, already monitoring MongoDB queries.")
 			} else if err != nil {
@@ -617,7 +617,7 @@ Type ssm-admin add mongodb:queries --help to see all acceptable flags.
 				os.Exit(1)
 			}
 			mongodbQueries := mongodbQueries.New(flagQueries, flagMongoURI, admin.Args, ssm.SSMBaseDir)
-			info, err := admin.AddQueries(ctx, mongodbQueries)
+			info, err := admin.AddQueries(ctx, mongodbQueries, nil)
 			if err == ssm.ErrDuplicate {
 				fmt.Println("Error adding MongoDB queries:", err)
 				os.Exit(1)
@@ -1620,7 +1620,7 @@ func main() {
 	cmdConfig.Flags().StringVar(&flagC.ClientAddress, "client-address", "", "client address, also remote/public address for this system (if omitted it will be automatically detected by asking server)")
 	cmdConfig.Flags().StringVar(&flagC.BindAddress, "bind-address", "", "bind address, also local/private address that is mapped from client address via NAT/port forwarding (defaults to the client address)")
 	cmdConfig.Flags().StringVar(&flagC.ClientName, "client-name", "", "client name (defaults to the system hostname)")
-	cmdConfig.Flags().StringVar(&flagC.ServerUser, "server-user", "pmm", "define HTTP user configured on SSM Server")
+	cmdConfig.Flags().StringVar(&flagC.ServerUser, "server-user", "ssm", "define HTTP user configured on SSM Server")
 	cmdConfig.Flags().StringVar(&flagC.ServerPassword, "server-password", "", "define HTTP password configured on SSM Server")
 	cmdConfig.Flags().BoolVar(&flagC.ServerSSL, "server-ssl", false, "enable SSL to communicate with SSM Server")
 	cmdConfig.Flags().BoolVar(&flagC.ServerInsecureSSL, "server-insecure-ssl", false, "enable insecure SSL (self-signed certificate) to communicate with SSM Server")

--- a/ssm/metrics.go
+++ b/ssm/metrics.go
@@ -48,8 +48,8 @@ func (a *Admin) AddMetrics(ctx context.Context, m plugin.Metrics, force bool, di
 		return nil, err
 	}
 
-	if info.PMMUserPassword != "" {
-		a.Config.MySQLPassword = info.PMMUserPassword
+	if info.SSMUserPassword != "" {
+		a.Config.MySQLPassword = info.SSMUserPassword
 		err := a.writeConfig()
 		if err != nil {
 			return nil, err
@@ -63,7 +63,7 @@ func (a *Admin) AddMetrics(ctx context.Context, m plugin.Metrics, force bool, di
 		return nil, err
 	}
 	if consulSvc != nil {
-		return nil, ErrDuplicate
+		return info, ErrDuplicate
 	}
 
 	if err := a.checkGlobalDuplicateService(serviceType, a.ServiceName); err != nil {

--- a/ssm/plugin/constants.go
+++ b/ssm/plugin/constants.go
@@ -36,3 +36,7 @@ const (
 	MySQLQueries      = "mysql:queries"
 	MongoDBQueries    = "mongodb:queries"
 )
+
+const (
+	SSMUsername = "ssm"
+)

--- a/ssm/plugin/info.go
+++ b/ssm/plugin/info.go
@@ -8,5 +8,5 @@ type Info struct {
 	Version         string
 	DSN             string
 	QuerySource     string
-	PMMUserPassword string
+	SSMUserPassword string
 }

--- a/ssm/plugin/mongodb/queries/queries.go
+++ b/ssm/plugin/mongodb/queries/queries.go
@@ -29,7 +29,7 @@ type Queries struct {
 }
 
 // Init initializes plugin.
-func (q *Queries) Init(ctx context.Context, pmmUserPassword string) (*plugin.Info, error) {
+func (q *Queries) Init(ctx context.Context, ssmUserPassword string, _ *plugin.Info) (*plugin.Info, error) {
 	info, err := mongodb.Init(ctx, q.dsn, q.args, q.pmmBaseDir)
 	if err != nil {
 		return nil, err

--- a/ssm/plugin/mysql/queries/queries.go
+++ b/ssm/plugin/mysql/queries/queries.go
@@ -38,10 +38,14 @@ type Queries struct {
 }
 
 // Init initializes plugin.
-func (q *Queries) Init(ctx context.Context, pmmUserPassword string) (*plugin.Info, error) {
-	info, err := mysql.Init(ctx, q.mysqlFlags, pmmUserPassword)
-	if err != nil {
-		return nil, err
+func (q *Queries) Init(ctx context.Context, ssmUserPassword string, info *plugin.Info) (*plugin.Info, error) {
+	var err error
+
+	if info == nil {
+		info, err = mysql.Init(ctx, q.mysqlFlags, ssmUserPassword)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if q.flags.QuerySource == "auto" {

--- a/ssm/plugin/queries.go
+++ b/ssm/plugin/queries.go
@@ -14,7 +14,7 @@ type QueriesFlags struct {
 // Queries is a common interface for all Query Analytics plugins.
 type Queries interface {
 	// Init initializes plugin and returns Info about database.
-	Init(ctx context.Context, pmmUserPassword string) (*Info, error)
+	Init(ctx context.Context, ssmUserPassword string, info *Info) (*Info, error)
 	// Name of the queries.
 	// As the time of writing this is limited to mysql and mongodb.
 	Name() string

--- a/ssm/queries.go
+++ b/ssm/queries.go
@@ -38,14 +38,14 @@ import (
 )
 
 // AddQueries add instance to Query Analytics.
-func (a *Admin) AddQueries(ctx context.Context, q plugin.Queries) (*plugin.Info, error) {
-	info, err := q.Init(ctx, a.Config.MySQLPassword)
+func (a *Admin) AddQueries(ctx context.Context, q plugin.Queries, prevInfo *plugin.Info) (*plugin.Info, error) {
+	info, err := q.Init(ctx, a.Config.MySQLPassword, prevInfo)
 	if err != nil {
 		return nil, err
 	}
 
-	if info.PMMUserPassword != "" {
-		a.Config.MySQLPassword = info.PMMUserPassword
+	if info.SSMUserPassword != "" {
+		a.Config.MySQLPassword = info.SSMUserPassword
 		err := a.writeConfig()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Close https://github.com/shatteredsilicon/ssm-submodules/issues/338

Also fixed another 2 relevant bugs:

1. When you pass `--create-user` and `--create-user-password xxx` at the same time, it will exit with an error saying that 'flag --create-user-password should be used along with --create-user', even though that's exactly how you used it.

![image](https://github.com/user-attachments/assets/2f85f625-3fc7-4c5f-9b19-f9e95c69cbb1)

2. When you run `ssm-admin add mysql --create-user ...`,  it will create 3 services `linux:metrics`, `mysql:metrics` and `mysql:queries` in order, but when it tries to create the `mysql:queries` service, it will encounter an '* MySQL user pmm@localhost already exists. Try without --create-user flag using the default credentials or specify the existing `pmm` user ones.' error, because the user is already created when it was creating the `mysql:metrics` service.

![image](https://github.com/user-attachments/assets/6514ee10-a826-4e61-8af2-96af951021bc)
