### PR TITLE
Add --ntp-host flag for customizing NTP server

### DIFF
--- a/ssm-admin.go
+++ b/ssm-admin.go
@@ -1183,7 +1183,7 @@ In case, some of the endpoints are in problem state, please check if the corresp
 If all endpoints are down here and 'ssm-admin list' shows all services are up,
 please check the firewall settings whether this system allows incoming connections by address:port in question.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := admin.CheckNetwork(); err != nil {
+			if err := admin.CheckNetwork(flagNTPHost); err != nil {
 				fmt.Println("Error checking network status:", err)
 				os.Exit(1)
 			}
@@ -1551,6 +1551,8 @@ Usually, it runs automatically when ssm-client package is upgraded to upgrade lo
 	flagMySQLQueries mysqlQueries.Flags
 	flagC            ssm.Config
 	flagTimeout      time.Duration
+
+	flagNTPHost string
 )
 
 func main() {
@@ -1625,6 +1627,7 @@ func main() {
 	cmdConfig.Flags().BoolVar(&flagC.ServerSSL, "server-ssl", false, "enable SSL to communicate with SSM Server")
 	cmdConfig.Flags().BoolVar(&flagC.ServerInsecureSSL, "server-insecure-ssl", false, "enable insecure SSL (self-signed certificate) to communicate with SSM Server")
 	cmdConfig.Flags().BoolVar(&flagForce, "force", false, "force to set client name on initial setup after uninstall with unreachable server")
+	cmdConfig.Flags().StringVar(&flagC.NTPHost, "ntp-host", "", "NTP server to use")
 
 	cmdAdd.PersistentFlags().IntVar(&flagServicePort, "service-port", 0, "service port")
 
@@ -1757,6 +1760,8 @@ func main() {
 	cmdRestart.Flags().BoolVar(&flagAll, "all", false, "restart all monitoring services")
 	cmdEnable.Flags().BoolVar(&flagAll, "all", false, "enable all monitoring services")
 	cmdDisable.Flags().BoolVar(&flagAll, "all", false, "disable all monitoring services")
+
+	cmdCheckNet.Flags().StringVar(&flagNTPHost, "ntp-host", "", "NTP server to use")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/ssm/check_network.go
+++ b/ssm/check_network.go
@@ -34,8 +34,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	defaultNTPHost = "0.pool.ntp.org"
+)
+
 // CheckNetwork check connectivity between client and server.
-func (a *Admin) CheckNetwork() error {
+func (a *Admin) CheckNetwork(ntpHost string) error {
 	// Check QAN API health.
 	qanStatus := false
 	url := a.qanAPI.URL(a.serverURL, qanAPIBasePath, "ping")
@@ -66,7 +70,13 @@ func (a *Admin) CheckNetwork() error {
 		timeFormat := "2006-01-02 15:04:05 -0700 MST"
 
 		// Real time (ntp server time)
-		ntpHost := "0.pool.ntp.org"
+		if ntpHost == "" {
+			ntpHost = a.Config.NTPHost
+		}
+		if ntpHost == "" {
+			ntpHost = defaultNTPHost
+		}
+
 		var ntpResponse *ntp.Response
 		var ntpTimeErr error
 		// ntp.Time() has default timeout of 5s, which should be enough,
@@ -83,7 +93,7 @@ func (a *Admin) CheckNetwork() error {
 		}
 		ntpTimeText := ""
 		if ntpTimeErr != nil {
-			ntpTimeText = fmt.Sprintf("unable to get ntp time: %s", err)
+			ntpTimeText = fmt.Sprintf("unable to get ntp time: %s", ntpTimeErr)
 		} else {
 			ntpTimeText = ntpResponse.Time.Format(timeFormat)
 		}

--- a/ssm/config.go
+++ b/ssm/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	ServerSSL         bool      `yaml:"server_ssl,omitempty"`
 	ServerInsecureSSL bool      `yaml:"server_insecure_ssl,omitempty"`
 	ManagedAPIPath    string    `yaml:"managed_api_path"`
+	NTPHost           string    `yaml:"ntp_host,omitempty"`
 	CTime             time.Time `yaml:"-"` // read from ctime
 }
 
@@ -118,6 +119,10 @@ func (a *Admin) SetConfig(cf Config, flagForce bool) error {
 	if cf.ServerInsecureSSL {
 		a.Config.ServerSSL = false
 		a.Config.ServerInsecureSSL = true
+	}
+
+	if cf.NTPHost != "" {
+		a.Config.NTPHost = cf.NTPHost
 	}
 
 	// Set APIs and check if server is alive.


### PR DESCRIPTION
Added a `--ntp-host` flag for `ssm-admin check-network` and `ssm-admin config ...` command, users can use it to change the NTP server, default is `0.pool.ntp.org` (currently used)

```sh
# ssm-admin check-network --ntp-host time.cloudflare.com
SSM Network Status

Server Address | 10.88.0.2
Client Address | 10.88.0.3 

* System Time
NTP Server (time.cloudflare.com)    | 2025-01-22 04:05:23 +0000 UTC
SSM Server                          | 2025-01-22 04:05:23 +0000 GMT
SSM Client                          | 2025-01-22 04:05:24 +0000 UTC
...
```

Close https://github.com/shatteredsilicon/ssm-submodules/issues/375