### PR TITLE
[Issue-351] Improve the "ssm-admin list --json" command to print out a pretty SON with indentation

### DIFF
--- a/ssm/external.go
+++ b/ssm/external.go
@@ -28,26 +28,26 @@ import (
 )
 
 type ExternalLabelPair struct {
-	Name  string
-	Value string
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 type ExternalTarget struct {
-	Target string
-	Labels []ExternalLabelPair
-	Health string
+	Target string              `json:"target"`
+	Labels []ExternalLabelPair `json:"labels"`
+	Health string              `json:"health"`
 }
 
 // ExternalMetrics represents external Prometheus exporter configuration: job and targets.
 // Field names are used for JSON output, so do not rename them.
 // JSON output uses Prometheus and pmm-managed API terms; TUI uses terms aligned with other commands.
 type ExternalMetrics struct {
-	JobName        string
-	ScrapeInterval time.Duration // nanoseconds in JSON
-	ScrapeTimeout  time.Duration // nanoseconds in JSON
-	MetricsPath    string
-	Scheme         string
-	Targets        []ExternalTarget
+	JobName        string           `json:"job_name"`
+	ScrapeInterval time.Duration    `json:"scrape_interval"` // nanoseconds in JSON
+	ScrapeTimeout  time.Duration    `json:"scrape_timeout"`  // nanoseconds in JSON
+	MetricsPath    string           `json:"metrics_path"`
+	Scheme         string           `json:"scheme"`
+	Targets        []ExternalTarget `json:"targets"`
 }
 
 // ListExternalMetrics returns external Prometheus exporters.

--- a/ssm/list.go
+++ b/ssm/list.go
@@ -20,6 +20,7 @@ package ssm
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -33,14 +34,14 @@ import (
 
 // Service status description.
 type ServiceStatus struct {
-	Type     string
-	Name     string
-	Port     string
-	Running  bool
-	DSN      string
-	Options  string
-	SSL      string
-	Password string
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+	Port     string `json:"port"`
+	Running  bool   `json:"running"`
+	DSN      string `json:"dsn"`
+	Options  string `json:"options"`
+	SSL      string `json:"ssl"`
+	Password string `json:"password"`
 }
 
 // Sort rows of formatted table output (list, check-networks commands).
@@ -68,13 +69,13 @@ func (s sortOutput) Less(i, j int) bool {
 }
 
 type List struct {
-	Version string
+	Version string `json:"version"`
 	ServerInfo
-	Platform         string
-	Err              string
-	Services         []ServiceStatus
-	ExternalErr      string
-	ExternalServices []ExternalMetrics
+	Platform         string            `json:"platform"`
+	Err              string            `json:"error,omitempty"`
+	Services         []ServiceStatus   `json:"services"`
+	ExternalErr      string            `json:"external_error,omitempty"`
+	ExternalServices []ExternalMetrics `json:"external_services"`
 }
 
 // Table formats *List.Services as table and returns result as string.
@@ -147,6 +148,14 @@ func (l *List) ExternalTable() string {
 
 // Format formats *List with provided format template and returns result as string.
 func (l *List) Format(format string) string {
+	if format == "{{ json . }}" || format == "json" {
+		out, err := json.MarshalIndent(l, "", "  ")
+		if err != nil {
+			return fmt.Sprintf("JSON marshal error: %v", err)
+		}
+		return string(out)
+	}
+
 	b := &bytes.Buffer{}
 	w := tabwriter.NewWriter(b, 8, 8, 8, ' ', 0)
 

--- a/ssm/ssm.go
+++ b/ssm/ssm.go
@@ -215,11 +215,11 @@ const (
 )
 
 type ServerInfo struct {
-	ServerAddress     string
-	ServerSecurity    string
-	ClientName        string
-	ClientAddress     string
-	ClientBindAddress string
+	ServerAddress     string `json:"server_address"`
+	ServerSecurity    string `json:"server_security"`
+	ClientName        string `json:"client_name"`
+	ClientAddress     string `json:"client_address"`
+	ClientBindAddress string `json:"client_bind_address"`
 }
 
 // ServerInfo print server info.


### PR DESCRIPTION
Resolves https://github.com/shatteredsilicon/ssm-submodules/issues/351

Sample of JSON output

```
[thien@flak ~/debug_ssm_client]$ sudo ssm-admin list --json
{
  "version": "9.4.7-1",
  "server_address": "172.17.0.2",
  "server_security": "(password-protected)",
  "client_name": "flak",
  "client_address": "172.17.0.1",
  "client_bind_address": "",
  "platform": "linux-systemd",
  "services": [
    {
      "type": "linux:metrics",
      "name": "flak",
      "port": "42000",
      "running": true,
      "dsn": "-",
      "options": "region=client, distro=Linux, version=5.4.291-1.el8.aarch64",
      "ssl": "",
      "password": ""
    }
  ],
  "external_services": []
}
```